### PR TITLE
close #135

### DIFF
--- a/capsul/engine/module/spm.py
+++ b/capsul/engine/module/spm.py
@@ -4,7 +4,6 @@ import os.path as osp
 import weakref
 import subprocess
 
-
 from soma.controller import Controller
 from soma.functiontools import SomaPartial
 from traits.api import Directory, Undefined, Instance, String, Bool
@@ -78,55 +77,74 @@ def auto_configuration(capsul_engine):
     '''
     Try to automatically set the capsul_engine configuration for SPM.
     '''
-#    if capsul_engine.spm.directory is not Undefined:
+
+    if capsul_engine.spm.directory is not Undefined:
 #        mcr = glob.glob(osp.join(capsul_engine.spm.directory, 'spm*_mcr'))
 #        if mcr:
 #            capsul_engine.spm.version = osp.basename(mcr[0])[3:-4]
 #            capsul_engine.spm.standalone = True
-#        else:
-#            capsul_engine.spm.standalone = False
-#            # determine SPM version (currently 8 or 12)
-#            if osp.isdir(osp.join(
-#                    capsul_engine.spm.directory, 'toolbox', 'OldNorm')):
-#                capsul_engine.spm.version = '12'
-#            elif os.path.isdir(os.path.join(
-#                capsul_engine.spm.directory, 'templates')):
-#                capsul_engine.spm.version = '8'
-#            else:
-#                if capsul_engine.spm.version is not Undefined:
-#                    del capsul_engine.spm.version
+# It seems that spm*_mcr does not always exist.
+# Nevertheless, *spm*.sh for MacOS, Linux, and *spm*.exe for Windows, yes !
+                                                                  # MacOS, Linux
+        mcr = glob.glob(osp.join(capsul_engine.spm.directory, '*spm*.sh'))
 
-# it seems that spm*_mcr does not always exist. run_spm*.sh yes ?
-    if capsul_engine.spm.directory is not Undefined:
-        mcr= glob.glob(osp.join(capsul_engine.spm.directory, 'run_spm*.sh'))
+        if not mcr:                                                    # Windows
+            mcr = glob.glob(osp.join(capsul_engine.spm.directory, '*spm*.exe'))
+            
         if mcr:
-            capsul_engine.spm.version = osp.basename(mcr[0])[7:-3]
+            fileName = osp.basename(mcr[0])
+            inc = 1
+
+            while fileName[fileName.find('spm') + 3:
+                           fileName.find('spm') + 3 + inc].isdigit():
+                capsul_engine.spm.version = fileName[fileName.find('spm') + 3:
+                                                     fileName.find('spm') + 3
+                                                                          + inc]
+                inc+=1
+        
             capsul_engine.spm.standalone = True
+            
         else:
             capsul_engine.spm.standalone = False
+            # determine SPM version (currently 8 or 12)
+            if osp.isdir(osp.join(
+                    capsul_engine.spm.directory, 'toolbox', 'OldNorm')):
+                capsul_engine.spm.version = '12'
+            elif os.path.isdir(os.path.join(
+                capsul_engine.spm.directory, 'templates')):
+                capsul_engine.spm.version = '8'
 
-            matlab_cmd = 'addpath("' + capsul_engine.spm.directory + '"); [name, ~]=spm("Ver"); fprintf(2, \"%s\", name(4:end)); exit'
-            
-            try:
-                p = subprocess.Popen([capsul_engine.matlab.executable, '-nodisplay', '-nodesktop', '-nosplash', '-singleCompThread', '-batch', matlab_cmd], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-                output,err = p.communicate()
-                rc = p.returncode
-
-            except FileNotFoundError as e:
-                print('\n {0}'.format(e))
-                rc = 111
-
-            except Exception as e:
-                print('\n {0}'.format(e))
-                rc = 111
-
-            if rc == 0:
-                 capsul_engine.spm.version = err.decode("utf-8")
-
-            else:
-                 
-                if capsul_engine.spm.version is not Undefined:
-                    del capsul_engine.spm.version
-
-            if (rc != 111) and (rc != 0):
-                print(err)
+# For SPM with MATLAB license, if we want to get the SPM version from a system
+# call to matlab:.
+#            matlab_cmd = ('addpath("' + capsul_engine.spm.directory + '");'
+#                          ' [name, ~]=spm("Ver");'
+#                          ' fprintf(2, \"%s\", name(4:end));'
+#                          ' exit')
+#
+#            try:
+#                p = subprocess.Popen([capsul_engine.matlab.executable,
+#                                       '-nodisplay', '-nodesktop',
+#                                       '-nosplash', '-singleCompThread',
+#                                       '-batch', matlab_cmd],
+#                                     stdin=subprocess.PIPE,
+#                                     stdout=subprocess.PIPE,
+#                                     stderr=subprocess.PIPE)
+#                output, err = p.communicate()
+#                rc = p.returncode
+#
+#            except FileNotFoundError as e:
+#                print('\n {0}'.format(e))
+#                rc = 111
+#
+#            except Exception as e:
+#                print('\n {0}'.format(e))
+#                rc = 111
+#
+#            if (rc != 111) and (rc != 0):
+#                print(err)
+#
+#            if rc == 0:
+#                 capsul_engine.spm.version = err.decode("utf-8")
+#
+            elif capsul_engine.spm.version is not Undefined:
+                del capsul_engine.spm.version

--- a/capsul/engine/module/spm.py
+++ b/capsul/engine/module/spm.py
@@ -2,7 +2,7 @@ import glob
 import os
 import os.path as osp
 import weakref
-import subprocess
+#import subprocess # Only in case of matlab call (auto_configuration func)
 
 from soma.controller import Controller
 from soma.functiontools import SomaPartial
@@ -42,7 +42,7 @@ def update_execution_context(capsul_engine):
 
 def check_spm_configuration(capsul_engine):
     '''
-    Check thas capsul_engine configuration is valid to call SPM commands.
+    Check that capsul_engine configuration is valid to call SPM commands.
     If not, try to automatically configure SPM. Finally raises an
     EnvironmentError if configuration is still wrong.
     '''


### PR DESCRIPTION
It seems that spm*_mcr does not exit always in all spm standalone version. On a MacOs of the lab there is not this file. I started discussion with Guillaume Flandrin (SPM developer), but he just leave in vacation (so  I have not the last answer to my last question ...).
However, I have the feelling that run_spm*.sh file should be more robust to determine the standalone spm version (I wait for this answer to be completely sure). I took the opportunity to determine the version of spm directly from a matlab call in case of a non-standalone spm version (more robust than searching, as before, from a files name .....  what will happen when a new version exists!)