### PR TITLE
mia crash when deleting a link in a pipeline.

### DIFF
--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -332,7 +332,7 @@ class Pipeline(Process):
                 for link in plug.links_from:
                     src = '%s.%s' % (link[0], link[1])
                     links_to_remove.append('%s->%s' % (src, name))
-                for link in links_to_remove    
+                for link in links_to_remove:    
                     self.remove_link(link)
                 del self.pipeline_node.plugs[name]
 

--- a/capsul/pipeline/pipeline.py
+++ b/capsul/pipeline/pipeline.py
@@ -316,23 +316,25 @@ class Pipeline(Process):
         name: str (mandatory)
             the trait name
         """
-        trait = self.traits()[name]
+        if name in self.traits():
+            trait = self.traits()[name]
 
         # If we remove a user trait, clear/remove the associated plug
-        if self.is_user_trait(trait):
-            plug = self.pipeline_node.plugs[name]
-            links_to_remove = []
+            if (self.is_user_trait(trait) and
+              name in self.pipeline_node.plugs):
+                plug = self.pipeline_node.plugs[name]
+                links_to_remove = []
             # use intermediary links_to_remove to avoid modifying the links set
             # while iterating on it...
-            for link in plug.links_to:
-                dst = '%s.%s' % (link[0], link[1])
-                links_to_remove.append('%s->%s' % (name, dst))
-            for link in plug.links_from:
-                src = '%s.%s' % (link[0], link[1])
-                links_to_remove.append('%s->%s' % (src, name))
-            for link in links_to_remove:
-                self.remove_link(link)
-            del self.pipeline_node.plugs[name]
+                for link in plug.links_to:
+                    dst = '%s.%s' % (link[0], link[1])
+                    links_to_remove.append('%s->%s' % (name, dst))
+                for link in plug.links_from:
+                    src = '%s.%s' % (link[0], link[1])
+                    links_to_remove.append('%s->%s' % (src, name))
+                for link in links_to_remove    
+                    self.remove_link(link)
+                del self.pipeline_node.plugs[name]
 
         # Remove the trait
         super(Pipeline, self).remove_trait(name)

--- a/capsul/qt_gui/widgets/pipeline_developper_view.py
+++ b/capsul/qt_gui/widgets/pipeline_developper_view.py
@@ -4104,18 +4104,17 @@ class PipelineDevelopperView(QGraphicsView):
         self.scene.update_pipeline()
 
     def _del_link(self):
-        print(self._current_link)
+        print('\nRemoving the link: ', self._current_link)
         src_node, src_plug, dst_node, dst_plug = self._current_link_def
         link_def = self._current_link
         pipeline = self.scene.pipeline
         pipeline.remove_link(link_def)
-        if src_node in ('', 'inputs'):
-            if len(pipeline.pipeline_node.plugs[src_plug].links_to) == 0:
+        if (src_node in ('', 'inputs') and
+          len(pipeline.pipeline_node.plugs[src_plug].links_to) == 0):
                 # remove orphan pipeline plug
-                pipeline.remove_trait(src_plug)
-        elif dst_node is ('', 'outputs') \
-                and len(pipeline.pipeline_node.plugs[dst_plug].links_from) \
-                    == 0:
+            pipeline.remove_trait(src_plug)
+        elif (dst_node in ('', 'outputs') and
+          len(pipeline.pipeline_node.plugs[dst_plug].links_from) == 0):
             # remove orphan pipeline plug
             pipeline.remove_trait(dst_plug)
         self.scene.update_pipeline()


### PR DESCRIPTION
Deleting a link in mia, calls:
1. in capsul/qt_gui/widgets/pipeline/developper_view.py:
    - in PipelineDevelopperView(QGraphicsView) class
        - _del_link(self) method
            The PipelineDevelopperView._del_link() method use the capsul.pipeline.pipeline.Pipeline.remove_trait(src_plug) method

2. in capsul/pipeline/pipeline.py
    - in Pipeline(Process) class
         - remove_trait(self, name):
        The Pipeline.remove_trait() method use:
            super(Pipeline, self).remove_trait(name)
        The Pipeline class inherits from the capsul.process.process.process.Process class which itself inherits from soma.controller.Controller class

3. in soma/controller/controller.py
    - in Controller(HasTraits)
        - remove_trait(self, name):
        The Controller.remove_trait() use:
           super(Controller, self).remove_trait(name)

4. in traits/has_traits.py:
     - in HasTraits(CHasTraits)
         - remove_trait(self, name)
        The HasTraits .remove_trait() method try to remove sub-traits (handler.has_items or handler.is_mapped) by changing the name attibute and using the self.remove_trait() method.

In this case self is a capsul.pipeline.pipeline.Pipeline object (point 2- vide supra) ....  and with this capsul.pipeline.pipeline.Pipeline object, the traits() method do not find the newly defined name attribute !

There are at least 2 options to solve this issue. I propose to just check if the attribute name is in the scope of the traits() method during the capsul.pipeline.pipeline.Pipeline.remove_trait(self, name) call.
I took also the opportunity to correct one typo.