### PR TITLE
Attempt to prevent the "RecursionError" exception

### DIFF
--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -254,6 +254,8 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
         """Ensure that trait.output and trait.optional are set to a
         boolean value before calling parent class add_trait.
         """
+        if not "_metadata" in trait.__dict__:
+            trait._metadata = {}
         if trait._metadata is not None:
             trait._metadata['output'] = bool(trait.output)
             trait._metadata['optional'] = bool(trait.optional)


### PR DESCRIPTION
... if the Traits package does not create the attribute _metadata.
