### PR TITLE
No stdout print if no message expected in capsul.process.process.Process.check_requirements()

### DIFF
--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -1155,18 +1155,17 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
         success = True
         for module in req:
             module_name = settings.module_name(module)
-            if module_name not in config:
+            if module_name not in config and message_list is not None:
+                message_list.append('requirement: %s is not met in %s'
+                                    % (req, self.name))
+            elif module_name not in config:
+                # if no message is expected, then we can return immediately
+                # without checking further requirements. Otherwise we
+                # continue to get a full list of unsatisfied requirements.
                 print('requirement:', req, 'not met in', self.name)
                 print('config:', settings.select_configurations(environment))
-                if message_list is not None:
-                    message_list.append('requirement: %s is not met in %s'
-                                        % (req, self.name))
-                else:
-                    # if no message is expected, then we can return immediately
-                    # without checking further requirements. Otherwise we
-                    # continue to get a full list of unsatisfied requirements.
-                    return None
-                success = False
+                return None
+            success = False
         if success:
             return config
         else:


### PR DESCRIPTION
We do not need to print a message in the stdout if the module name is not in the configuration parameters and no message is expected. The print in stdout can be managed in mia.