### PR TITLE
allow the specification if workflow when starting engine

### DIFF
--- a/capsul/engine/__init__.py
+++ b/capsul/engine/__init__.py
@@ -378,7 +378,7 @@ class CapsulEngine(Controller):
         pipeline.autoexport_nodes_parameters(include_optional=True)
         return pipeline
 
-    def start(self, process, history=True, get_pipeline=False, **kwargs):
+    def start(self, process, workflow=None, history=True, get_pipeline=False, **kwargs):
         '''
         Asynchronously start the execution of a process or pipeline in the
         connected computing environment. Returns an identifier of
@@ -395,6 +395,7 @@ class CapsulEngine(Controller):
         Parameters
         ----------
         process: Process or Pipeline instance
+        workflow: Workflow instance (optional - if already defined before call)
         history: bool (optional)
             TODO: not implemented yet.
         get_pipeline: bool (optional)
@@ -412,7 +413,7 @@ class CapsulEngine(Controller):
         pipeline: Pipeline instance (optional)
             only returned if get_pipeline is True.
         '''
-        return run.start(self, process, history, get_pipeline, **kwargs)
+        return run.start(self, process, workflow, history, get_pipeline, **kwargs)
 
     def connect(self, computing_resource):
         '''

--- a/capsul/engine/run.py
+++ b/capsul/engine/run.py
@@ -113,7 +113,7 @@ class WorkflowExecutionError(Exception):
             % (status, wk, wc, precisions))
 
 
-def start(engine, process, history=True, get_pipeline=False, **kwargs):
+def start(engine, process, workflow=None, history=True, get_pipeline=False, **kwargs):
     '''
     Asynchronously start the execution of a process or pipeline in the
     connected computing environment. Returns an identifier of
@@ -131,6 +131,7 @@ def start(engine, process, history=True, get_pipeline=False, **kwargs):
     ----------
     engine: CapsulEngine
     process: Process or Pipeline instance
+    workflow: Workflow instance (optional - if already defined before call)
     history: bool (optional)
         TODO: not implemented yet.
     get_pipeline: bool (optional)
@@ -169,7 +170,8 @@ def start(engine, process, history=True, get_pipeline=False, **kwargs):
     from capsul.pipeline.pipeline_workflow import workflow_from_pipeline
     import soma_workflow.client as swclient
 
-    workflow = workflow_from_pipeline(process)
+    if workflow is None:
+        workflow = workflow_from_pipeline(process)
 
     swm = engine.study_config.modules['SomaWorkflowConfig']
     swm.connect_resource(engine.connected_to())
@@ -331,7 +333,7 @@ def dispose(engine, execution_id, conditional=False):
 
 
 def call(engine, process, history=True, **kwargs):
-    eid, pipeline = engine.start(process, history=history, get_pipeline=True,
+    eid, pipeline = engine.start(process, workflow=None, history=history, get_pipeline=True,
                                  **kwargs)
     status = engine.wait(eid, pipeline=pipeline)
     engine.dispose(eid, conditional=True)
@@ -339,7 +341,7 @@ def call(engine, process, history=True, **kwargs):
 
 
 def check_call(engine, process, history=True, **kwargs):
-    eid, pipeline = engine.start(process, history=history, get_pipeline=True,
+    eid, pipeline = engine.start(process, workflow=None, history=history, get_pipeline=True,
                                  **kwargs)
     status = engine.wait(eid, pipeline=pipeline)
     try:


### PR DESCRIPTION
Modification of the engine.start function and run.start functions to allow the specification of the workflow. This allow to handle cases where workflow is already defined before start (e.g. in MIA we define it during initialization).
When workflow is not specified, set it automatically to none, and define it with workflow_from_pipeline function in run.start (as before)