### PR TITLE
Allow loading JSON pipelines as Python package resources

### DIFF
--- a/capsul/application.py
+++ b/capsul/application.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import dataclasses
 import importlib
+import importlib.resources
 import json
 from pathlib import Path
 import types
@@ -283,7 +284,21 @@ def executable(definition, **kwargs):
                     elif len(items) > 1:
                         raise ValueError(
                             f'Several process classes found in {definition}')
-                result = executable_from_python(definition, item)
+                if item is not None:
+                    result = executable_from_python(definition, item)
+                if result is None:
+                    # maybe a JSON-defined pipeline
+                    try:
+                        is_resource = importlib.resources.is_resource(
+                            module_name, object_name + '.json')
+                    except TypeError:  # if module_name is not a package
+                        is_resource = False
+                    if is_resource:
+                        with importlib.resources.open_text(
+                            module_name, object_name + '.json') as f:
+                            json_executable = json.load(f)
+                        result =  executable_from_json(definition,
+                                                       json_executable)
 
     if result is not None:
         for name, value in kwargs.items():


### PR DESCRIPTION
This addition allows to incorporate `.json` files containing custom pipeline definitions into a Python package. This is similar to the `.xml` pipelines that could be defined and imported in Capsul v2.