### PR TITLE
Fix crash with dot if node name start with <integer>_

### DIFF
--- a/capsul/pipeline/pipeline_tools.py
+++ b/capsul/pipeline/pipeline_tools.py
@@ -504,7 +504,7 @@ def save_dot_graph(dot_graph, filename, **kwargs):
                            for aname, val in six.iteritems(props)])
         if len(props) != 0:
             attstr = ' ' + attstr
-        fileobj.write('  %s [label="%s" style="filled"%s];\n'
+        fileobj.write('  "%s" [label="%s" style="filled"%s];\n'
                       % (id, node, attstr))
     for edge, descr in six.iteritems(dot_graph[1]):
         props = descr[0]


### PR DESCRIPTION
I just experienced a crash in Mia when we use graphviz/dot with a node name starting with integer_ (e.g. 1_foo).
I propose a very small change to fix it.