### PR TITLE
use xor and optional in get_missing_mandatory_parameters()

### DIFF
--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -1135,9 +1135,14 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
             elif not trait.optional:
                 xors = [i for i in trait.xor if not self.traits()[i].optional]
                 # Mutually exclusive means xors must have only one element?
-                value_xor = self.get_parameter(xors[0])
-                value = self.get_parameter(name)
-                if not check_trait(self.traits()[xors[0]], value_xor) and not check_trait(trait, value):
+                # value_xor = self.get_parameter(xors[0])
+                # value = self.get_parameter(name)
+                # if not check_trait(self.traits()[xors[0]], value_xor) and not check_trait(trait, value):
+                #     missing.append(name)
+                result_check = [check_trait(self.traits()[i],
+                                            self.get_parameter(i)) for i in xors]
+                result_check.append(check_trait(trait, self.get_parameter(name)))
+                if not any(result_check):
                     missing.append(name)
         return missing
 

--- a/capsul/process/process.py
+++ b/capsul/process/process.py
@@ -1126,10 +1126,18 @@ class Process(six.with_metaclass(ProcessMeta, Controller)):
             return trait.output or value not in (Undefined, None)
 
         missing = []
+
         for name, trait in six.iteritems(self.user_traits()):
-            if not trait.optional:
+            if not trait.optional and trait.xor is None:
                 value = self.get_parameter(name)
                 if not check_trait(trait, value):
+                    missing.append(name)
+            elif not trait.optional:
+                xors = [i for i in trait.xor if not self.traits()[i].optional]
+                # Mutually exclusive means xors must have only one element?
+                value_xor = self.get_parameter(xors[0])
+                value = self.get_parameter(name)
+                if not check_trait(self.traits()[xors[0]], value_xor) and not check_trait(trait, value):
                     missing.append(name)
         return missing
 


### PR DESCRIPTION
See #289.

Here we only modify capsul.process.Process.get_missing_mandatory_parameters(). Is it also necessary to modify capsul.pipeline.pipeline_nodes.Node.get_missing_mandatory_parameters()?

In this PR, we consider that only two parameters can be mutually exclusive. In fact, I don't know if this is the case for more than 2 parameters. If it's the case for more than 2 parameters, we need to change the `xor_value = self.get_parameter(xors[0])` and do the check on all elements (it's not a big change to do it if we have a doubt...). What do you think?