### PR TITLE
No need for `absolute_import` in Python 3

### DIFF
--- a/capsul/info.py
+++ b/capsul/info.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import os.path
 import sys
 

--- a/capsul/pipeline/custom_nodes/loo_node.py
+++ b/capsul/pipeline/custom_nodes/loo_node.py
@@ -4,7 +4,6 @@
 """
 
 
-from __future__ import absolute_import
 from capsul.process.node import Node
 from soma.controller import Controller, Any, type_from_str
 

--- a/capsul/pipeline/custom_nodes/map_node.py
+++ b/capsul/pipeline/custom_nodes/map_node.py
@@ -4,7 +4,6 @@
 """
 
 
-from __future__ import absolute_import
 from capsul.process.node import Node, Plug
 from soma.controller import Controller, File, undefined, field, type_from_str
 

--- a/capsul/pipeline/custom_nodes/strcat_node.py
+++ b/capsul/pipeline/custom_nodes/strcat_node.py
@@ -3,7 +3,6 @@
 -------------------
 """
 
-from __future__ import absolute_import
 from capsul.process.node import Node
 from soma.controller import Controller, Any, type_from_str
 

--- a/capsul/pipeline/python_export.py
+++ b/capsul/pipeline/python_export.py
@@ -7,9 +7,6 @@ Functions
 ------------------------
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 from soma.controller import Controller, undefined
 import os
 import sys

--- a/capsul/qt_apps/pipeline_viewer_app.py
+++ b/capsul/qt_apps/pipeline_viewer_app.py
@@ -6,7 +6,6 @@ Classes
 """
 
 # System import
-from __future__ import absolute_import
 import os
 import logging
 

--- a/capsul/qt_apps/utils/application.py
+++ b/capsul/qt_apps/utils/application.py
@@ -8,7 +8,6 @@ Classes
 """
 
 # System import
-from __future__ import absolute_import
 import sys
 import optparse
 import logging

--- a/capsul/qt_apps/utils/fill_treectrl.py
+++ b/capsul/qt_apps/utils/fill_treectrl.py
@@ -9,7 +9,6 @@ Functions
 ----------------------
 """
 
-from __future__ import absolute_import
 import six
 
 # Soma import

--- a/capsul/qt_apps/utils/window.py
+++ b/capsul/qt_apps/utils/window.py
@@ -6,7 +6,6 @@ Classes
 """
 
 # Soma import
-from __future__ import absolute_import
 from soma.qt_gui import qt_backend
 
 # Capsul import

--- a/capsul/qt_gui/widgets/links_debugger.py
+++ b/capsul/qt_gui/widgets/links_debugger.py
@@ -7,8 +7,6 @@ Classes
 -------------------------------
 """
 
-from __future__ import print_function
-
 # System import
 from __future__ import absolute_import
 import os

--- a/capsul/qt_gui/widgets/pipeline_user_view.py
+++ b/capsul/qt_gui/widgets/pipeline_user_view.py
@@ -7,8 +7,6 @@ Classes
 -------------------------
 """
 
-from __future__ import print_function
-
 # System import
 from __future__ import absolute_import
 import sys

--- a/capsul/sphinxext/capsul_pipeline_view.py
+++ b/capsul/sphinxext/capsul_pipeline_view.py
@@ -2,7 +2,6 @@
 """
 
 # System import
-from __future__ import absolute_import
 import os
 from optparse import OptionParser
 import logging

--- a/capsul/sphinxext/capsul_sphinx_layout.py
+++ b/capsul/sphinxext/capsul_sphinx_layout.py
@@ -11,7 +11,6 @@ installation index.
 """
 
 # System import
-from __future__ import absolute_import
 import os
 from optparse import OptionParser
 import logging

--- a/capsul/sphinxext/capsul_usecases_rst.py
+++ b/capsul/sphinxext/capsul_usecases_rst.py
@@ -8,7 +8,6 @@
 
 """Script to auto-generate use cases rst documentation.
 """
-from __future__ import print_function
 
 # System import
 from __future__ import absolute_import

--- a/capsul/sphinxext/layoutdocgen.py
+++ b/capsul/sphinxext/layoutdocgen.py
@@ -7,7 +7,6 @@
 ##########################################################################
 
 # System import
-from __future__ import absolute_import
 import os
 import sys
 import six

--- a/capsul/sphinxext/load_pilots.py
+++ b/capsul/sphinxext/load_pilots.py
@@ -7,7 +7,6 @@
 ##########################################################################
 
 # System import
-from __future__ import absolute_import
 import os
 import sys
 import logging

--- a/capsul/sphinxext/resources/custom_ext/hidden_code_block.py
+++ b/capsul/sphinxext/resources/custom_ext/hidden_code_block.py
@@ -32,7 +32,6 @@ Written by Anthony 'el Scopz' Scopatz, January 2012.
 Released under the WTFPL (http://sam.zoy.org/wtfpl/).
 """
 
-from __future__ import absolute_import
 from docutils import nodes
 from docutils.parsers.rst import directives
 from sphinx.directives.code import CodeBlock

--- a/capsul/sphinxext/resources/custom_ext/hidden_technical_block.py
+++ b/capsul/sphinxext/resources/custom_ext/hidden_technical_block.py
@@ -1,5 +1,4 @@
 # System import
-from __future__ import absolute_import
 import logging
 
 # Docutils import

--- a/capsul/sphinxext/resources/custom_ext/link_to_block.py
+++ b/capsul/sphinxext/resources/custom_ext/link_to_block.py
@@ -1,5 +1,4 @@
 # System import
-from __future__ import absolute_import
 import os
 
 # Docutils import

--- a/capsul/sphinxext/test/test_usercases_doc.py
+++ b/capsul/sphinxext/test/test_usercases_doc.py
@@ -1,8 +1,4 @@
-from __future__ import with_statement
-
 # System import
-from __future__ import absolute_import
-from __future__ import print_function
 import unittest
 
 # Capsul import

--- a/capsul/sphinxext/usecasesdocgen.py
+++ b/capsul/sphinxext/usecasesdocgen.py
@@ -7,7 +7,6 @@
 ##########################################################################
 
 # System import
-from __future__ import absolute_import
 import inspect
 import ast
 import os


### PR DESCRIPTION
It is the default in Python 3:
https://portingguide.readthedocs.io/en/latest/imports.html