### PR TITLE
Use the ruff formatter, instead of black

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
-# See https://pre-commit.com for more information
-# See https://pre-commit.com/hooks.html for more hooks
 exclude: '^(doc/source|capsul)/sphinxext/'
+
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -21,15 +20,14 @@ repos:
         exclude: \.min\.js$
     -   id: fix-byte-order-marker
     -   id: trailing-whitespace
--   repo: https://github.com/psf/black
-    rev: 23.11.0
+
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
-      - id: black
-#-   repo: https://github.com/astral-sh/ruff-pre-commit
-#    rev: v0.1.5
-#    hooks:
-#    -   id: ruff
-#        exclude: '^doc/'
+    #-   id: ruff
+    -   id: ruff-format
+        exclude: '^doc/'
+
 -   repo: https://github.com/PyCQA/flake8
     rev: 5.0.4
     hooks:

--- a/capsul/pipeline/pipeline_nodes.py
+++ b/capsul/pipeline/pipeline_nodes.py
@@ -385,7 +385,9 @@ class Switch(Node):
     def configured_controller(self):
         c = self.configure_controller()
         c.outputs = [
-            field.name for field in self.fields() if field.is_output()  # noqa: F811
+            field.name
+            for field in self.fields()
+            if field.is_output()  # noqa: F811
         ]
         c.inputs = self.get_switch_inputs()
         c.output_types = [self.field(p).type_str() for p in self.outputs]

--- a/capsul/pipeline/pipeline_nodes.py
+++ b/capsul/pipeline/pipeline_nodes.py
@@ -9,7 +9,7 @@ Classes
 
 import typing
 
-from soma.controller import Controller, field, undefined, Literal, List, type_from_str
+from soma.controller import Controller, undefined, Literal, List, type_from_str
 
 from ..process.node import Plug, Node
 

--- a/capsul/pipeline/test/fake_morphologist/brainorientation.py
+++ b/capsul/pipeline/test/fake_morphologist/brainorientation.py
@@ -398,9 +398,7 @@ class BrainOrientation(Pipeline):
         self.Normalization_NormalizeFSL_allow_retry_initialization = True
         self.Normalization_NormalizeFSL_NormalizeFSL_cost_function = "corratio"
         self.Normalization_NormalizeFSL_NormalizeFSL_search_cost_function = "corratio"
-        self.Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = (
-            0
-        )
+        self.Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = 0
         self.Normalization_NormalizeSPM_allow_retry_initialization = True
         self.Normalization_NormalizeSPM_voxel_size = "[1 1 1]"
         self.Normalization_NormalizeSPM_cutoff_option = 25

--- a/capsul/pipeline/test/fake_morphologist/morphologist.py
+++ b/capsul/pipeline/test/fake_morphologist/morphologist.py
@@ -1874,30 +1874,18 @@ class Morphologist(Pipeline):
         self.PrepareSubject_Normalization_NormalizeFSL_alignment = (
             "Not Aligned but Same Orientation"
         )
-        self.PrepareSubject_Normalization_NormalizeFSL_set_transformation_in_source_volume = (
-            True
-        )
+        self.PrepareSubject_Normalization_NormalizeFSL_set_transformation_in_source_volume = True
         self.PrepareSubject_Normalization_NormalizeFSL_NormalizeFSL_cost_function = (
             "corratio"
         )
-        self.PrepareSubject_Normalization_NormalizeFSL_NormalizeFSL_search_cost_function = (
-            "corratio"
-        )
-        self.PrepareSubject_Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = (
-            0
-        )
+        self.PrepareSubject_Normalization_NormalizeFSL_NormalizeFSL_search_cost_function = "corratio"
+        self.PrepareSubject_Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = 0
         self.PrepareSubject_Normalization_NormalizeSPM_voxel_size = "[1 1 1]"
         self.PrepareSubject_Normalization_NormalizeSPM_cutoff_option = 25
         self.PrepareSubject_Normalization_NormalizeSPM_nbiteration = 16
-        self.PrepareSubject_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_target = (
-            "MNI template"
-        )
-        self.PrepareSubject_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_removeSource = (
-            False
-        )
-        self.PrepareSubject_Normalization_NormalizeBaladin_set_transformation_in_source_volume = (
-            True
-        )
+        self.PrepareSubject_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_target = "MNI template"
+        self.PrepareSubject_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_removeSource = False
+        self.PrepareSubject_Normalization_NormalizeBaladin_set_transformation_in_source_volume = True
         self.PrepareSubject_Normalization_Normalization_AimsMIRegister_anatomical_template = "/casa/host/build/share/brainvisa-share-5.2/anatomical_templates/MNI152_T1_2mm.nii.gz"
         self.PrepareSubject_Normalization_Normalization_AimsMIRegister_mni_to_acpc = "/casa/host/build/share/brainvisa-share-5.2/transformation/talairach_TO_spm_template_novoxels.trm"
         self.PrepareSubject_Normalization_Normalization_AimsMIRegister_smoothing = 1.0
@@ -1940,21 +1928,15 @@ class Morphologist(Pipeline):
         self.Renorm_Normalization_NormalizeFSL_NormalizeFSL_search_cost_function = (
             "corratio"
         )
-        self.Renorm_Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = (
-            0
-        )
+        self.Renorm_Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = 0
         self.Renorm_Normalization_NormalizeSPM_voxel_size = "[1 1 1]"
         self.Renorm_Normalization_NormalizeSPM_cutoff_option = 25
         self.Renorm_Normalization_NormalizeSPM_nbiteration = 16
         self.Renorm_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_target = (
             "MNI template"
         )
-        self.Renorm_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_removeSource = (
-            False
-        )
-        self.Renorm_Normalization_NormalizeBaladin_set_transformation_in_source_volume = (
-            True
-        )
+        self.Renorm_Normalization_NormalizeSPM_ConvertSPMnormalizationToAIMS_removeSource = False
+        self.Renorm_Normalization_NormalizeBaladin_set_transformation_in_source_volume = True
         self.Renorm_Normalization_Normalization_AimsMIRegister_mni_to_acpc = "/casa/host/build/share/brainvisa-share-5.2/transformation/talairach_TO_spm_template_novoxels.trm"
         self.Renorm_Normalization_Normalization_AimsMIRegister_smoothing = 1.0
         self.SplitBrain_use_ridges = True

--- a/capsul/pipeline/test/fake_morphologist/normalizationskullstripped.py
+++ b/capsul/pipeline/test/fake_morphologist/normalizationskullstripped.py
@@ -344,9 +344,7 @@ class NormalizationSkullStripped(Pipeline):
         self.Normalization_NormalizeFSL_allow_retry_initialization = True
         self.Normalization_NormalizeFSL_NormalizeFSL_cost_function = "corratio"
         self.Normalization_NormalizeFSL_NormalizeFSL_search_cost_function = "corratio"
-        self.Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = (
-            0
-        )
+        self.Normalization_NormalizeFSL_ConvertFSLnormalizationToAIMS_standard_template = 0
         self.Normalization_NormalizeSPM_allow_retry_initialization = True
         self.Normalization_NormalizeSPM_voxel_size = "[1 1 1]"
         self.Normalization_NormalizeSPM_cutoff_option = 25

--- a/capsul/process/test/test_load_from_description.py
+++ b/capsul/process/test/test_load_from_description.py
@@ -84,9 +84,9 @@ def mask(
     pass
 
 
-def cat(
-    value1: str, value2: str, value3: str
-) -> field(type_=str, desc="Concatenation of non empty input values."):
+def cat(value1: str, value2: str, value3: str) -> field(
+    type_=str, desc="Concatenation of non empty input values."
+):
     return "_".join(i for i in (value1, value2, value3) if i)
 
 

--- a/capsul/schemas/brainvisa.py
+++ b/capsul/schemas/brainvisa.py
@@ -795,9 +795,7 @@ def declare_morpho_schemas(morpho_module):
 
     @process_schema("brainvisa_shared", Morphologist)
     def brainvisa_shared_Morphologist(metadata):
-        metadata.PrepareSubject_Normalization_Normalization_AimsMIRegister_anatomical_template.data_id = (
-            "normalization_template"
-        )
+        metadata.PrepareSubject_Normalization_Normalization_AimsMIRegister_anatomical_template.data_id = "normalization_template"
         metadata.PrepareSubject_Normalization_NormalizeFSL_template.data_id = (
             "normalization_template"
         )
@@ -807,22 +805,14 @@ def declare_morpho_schemas(morpho_module):
         metadata.PrepareSubject_Normalization_NormalizeBaladin_template.data_id = (
             "normalization_template"
         )
-        metadata.PrepareSubject_Normalization_Normalization_AimsMIRegister_mni_to_acpc.data_id = (
-            "trans_acpc_to_mni"
-        )
+        metadata.PrepareSubject_Normalization_Normalization_AimsMIRegister_mni_to_acpc.data_id = "trans_acpc_to_mni"
         metadata.PrepareSubject_TalairachFromNormalization_acpc_referential.data_id = (
             "acpc_ref"
         )
         metadata.Renorm_template.data_id = "normalization_template_brain"
-        metadata.Renorm_Normalization_Normalization_AimsMIRegister_mni_to_acpc.data_id = (
-            "trans_mni_to_acpc"
-        )
-        metadata.PrepareSubject_TalairachFromNormalization_normalized_referential.data_id = (
-            "icbm152_ref"
-        )
-        metadata.PrepareSubject_TalairachFromNormalization_transform_chain_ACPC_to_Normalized.data_id = (
-            "trans_acpc_to_mni"
-        )
+        metadata.Renorm_Normalization_Normalization_AimsMIRegister_mni_to_acpc.data_id = "trans_mni_to_acpc"
+        metadata.PrepareSubject_TalairachFromNormalization_normalized_referential.data_id = "icbm152_ref"
+        metadata.PrepareSubject_TalairachFromNormalization_transform_chain_ACPC_to_Normalized.data_id = "trans_acpc_to_mni"
         metadata.SplitBrain_split_template.data_id = "hemi_split_template"
         metadata.sulcal_morphometry_sulci_file.data_id = "sulcal_morphometry_sulci_file"
         metadata.SulciRecognition_recognition2000_model.data_id = (
@@ -839,164 +829,66 @@ def declare_morpho_schemas(morpho_module):
             "sulci_spam_recognition_labels_trans"
         )
         metadata.SPAM_recognition_labels_translation_map.model_version = "08"
-        metadata.SulciRecognition_SPAM_recognition09_global_recognition_model.data_id = (
-            "sulci_spam_recognition_global_model"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_global_recognition_model.model_version = (
-            "08"
-        )
+        metadata.SulciRecognition_SPAM_recognition09_global_recognition_model.data_id = "sulci_spam_recognition_global_model"
+        metadata.SulciRecognition_SPAM_recognition09_global_recognition_model.model_version = "08"
         metadata.SulciRecognition_SPAM_recognition09_global_recognition_model.side = "L"
-        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_model.data_id = (
-            "sulci_spam_recognition_global_model"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_model.model_version = (
-            "08"
-        )
+        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_model.data_id = "sulci_spam_recognition_global_model"
+        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_model.model_version = "08"
         metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_model.side = (
             "R"
         )
         metadata.SulciRecognition_SPAM_recognition09_local_recognition_model.data_id = (
             "sulci_spam_recognition_local_model"
         )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_model.model_version = (
-            "08"
-        )
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_model.model_version = "08"
         metadata.SulciRecognition_SPAM_recognition09_local_recognition_model.side = "L"
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_model.data_id = (
-            "sulci_spam_recognition_local_model"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_model.model_version = (
-            "08"
-        )
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_model.data_id = "sulci_spam_recognition_local_model"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_model.model_version = "08"
         metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_model.side = (
             "R"
         )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.data_id = (
-            "sulci_spam_recognition_global_model"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.data_id = (
-            "sulci_spam_recognition_global_model"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.side = (
-            "R"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.data_id = (
-            "sulci_spam_recognition_global_labels_priors"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.data_id = (
-            "sulci_spam_recognition_global_labels_priors"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.side = (
-            "R"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.data_id = (
-            "sulci_spam_recognition_local_refs"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.data_id = (
-            "sulci_spam_recognition_local_refs"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.side = (
-            "R"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.data_id = (
-            "sulci_spam_recognition_local_dir_priors"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.data_id = (
-            "sulci_spam_recognition_local_dir_priors"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.side = (
-            "L"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.data_id = (
-            "sulci_spam_recognition_local_angle_priors"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.data_id = (
-            "sulci_spam_recognition_local_angle_priors"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.side = (
-            "R"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.data_id = (
-            "sulci_spam_recognition_local_trans_priors"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.data_id = (
-            "sulci_spam_recognition_local_trans_priors"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.side = (
-            "R"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.data_id = (
-            "sulci_spam_recognition_markov_rels"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.side = (
-            "L"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.data_id = (
-            "sulci_spam_recognition_markov_rels"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.model_version = (
-            "08"
-        )
-        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.side = (
-            "R"
-        )
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.data_id = "sulci_spam_recognition_global_model"
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_model.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.data_id = "sulci_spam_recognition_global_model"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_model.side = "R"
+        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.data_id = "sulci_spam_recognition_global_labels_priors"
+        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_global_recognition_labels_priors.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.data_id = "sulci_spam_recognition_global_labels_priors"
+        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_global_recognition_labels_priors.side = "R"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.data_id = "sulci_spam_recognition_local_refs"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_local_referentials.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.data_id = "sulci_spam_recognition_local_refs"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_local_referentials.side = "R"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.data_id = "sulci_spam_recognition_local_dir_priors"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_direction_priors.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.data_id = "sulci_spam_recognition_local_dir_priors"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_direction_priors.side = "L"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.data_id = "sulci_spam_recognition_local_angle_priors"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_angle_priors.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.data_id = "sulci_spam_recognition_local_angle_priors"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_angle_priors.side = "R"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.data_id = "sulci_spam_recognition_local_trans_priors"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_local_recognition_translation_priors.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.data_id = "sulci_spam_recognition_local_trans_priors"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_local_recognition_translation_priors.side = "R"
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.data_id = "sulci_spam_recognition_markov_rels"
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.model_version = "08"
+        metadata.SulciRecognition_SPAM_recognition09_markovian_recognition_segments_relations_model.side = "L"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.data_id = "sulci_spam_recognition_markov_rels"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.model_version = "08"
+        metadata.SulciRecognition_1_SPAM_recognition09_markovian_recognition_segments_relations_model.side = "R"
         metadata.SulciRecognition_CNN_recognition19_model_file.data_id = (
             "sulci_cnn_recognition_model"
         )

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,21 @@
+[lint]
+extend-ignore = [
+  # https://docs.astral.sh/ruff/rules/redundant-open-modes/
+  # we prefer explicit to implicit open modes
+  "UP015",
+  # https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+  "W191",
+  "E111",
+  "E114",
+  "E117",
+  "D206",
+  "D300",
+  "Q000",
+  "Q001",
+  "Q002",
+  "Q003",
+  "COM812",
+  "COM819",
+  "ISC001",
+  "ISC002",
+]

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,4 +1,12 @@
+exclude = [
+  "sphinxext",
+]
+
 [lint]
+extend-select = [
+  "I",   # https://docs.astral.sh/ruff/rules/#isort-i
+  "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+]
 extend-ignore = [
   # https://docs.astral.sh/ruff/rules/redundant-open-modes/
   # we prefer explicit to implicit open modes


### PR DESCRIPTION
The ruff formatter seems to gain traction. Replacing [black](https://github.com/psf/black) with [ruff](https://github.com/astral-sh/ruff) means one less tool to depend on.

I have based this commit on:
- ruff-pre-commit [README.md](https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md) | Using Ruff with pre-commit
- The Ruff Formatter | [Conflicting lint rules](https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules)

Also add new ruff linter rules.