### PR TITLE
Start applying repo-review suggestions

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -7,7 +7,7 @@ extend-select = [
   "I",   # https://docs.astral.sh/ruff/rules/#isort-i
   "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
-extend-ignore = [
+ignore = [
   # https://docs.astral.sh/ruff/rules/redundant-open-modes/
   # we prefer explicit to implicit open modes
   "UP015",


### PR DESCRIPTION
See https://learn.scientific-python.org/development/guides/repo-review/?repo=populse%2Fcapsul&branch=3.0

**RF201: Avoid using deprecated config settings**
`extend-ignore` deprecated, use `ignore` instead (identical)