### PR TITLE
Apply repo-review suggestion: RF101: Bugbear must be selected

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -4,11 +4,15 @@ exclude = [
 
 [lint]
 extend-select = [
+  "B",   # https://docs.astral.sh/ruff/rules/#flake8-bugbear
   "I",   # https://docs.astral.sh/ruff/rules/#isort-i
   "UP",  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
 ]
 ignore = [
   # FIXME: apply the following rules
+  "B007",
+  "B023",
+  "B026",
   "F401",
   "F841",
   "E402",


### PR DESCRIPTION
**[RF101](https://learn.scientific-python.org/development/guides/style#RF101): Bugbear must be selected**
Must select the flake8-bugbear `B` checks.

Requires #356.

https://learn.scientific-python.org/development/guides/repo-review/?repo=populse%2Fcapsul&branch=3.0